### PR TITLE
astronomical barrier resist and corona resistance script refactoring

### DIFF
--- a/src/data/scripts/campaign/MPC_coronaResistScript.kt
+++ b/src/data/scripts/campaign/MPC_coronaResistScript.kt
@@ -1,7 +1,6 @@
 package data.scripts.campaign
 
 import com.fs.starfarer.api.campaign.*
-import com.fs.starfarer.api.fleet.FleetAPI
 import com.fs.starfarer.api.fleet.FleetMemberAPI
 import com.fs.starfarer.api.impl.campaign.ids.Stats
 import com.fs.starfarer.api.util.Misc
@@ -13,12 +12,8 @@ import data.utilities.niko_MPC_ids
 import data.utilities.niko_MPC_ids.CORONA_RESIST_MEMORY_FLAG
 import data.utilities.niko_MPC_industryIds
 import com.fs.starfarer.api.util.IntervalUtil
-//import org.apache.log4j.Logger;
-
-
 
 open class MPC_coronaResistScript(val entity: SectorEntityToken,): niko_MPC_baseNikoScript() {
-    //var logger: Logger = Logger.getLogger("MPC_coronaResistScript")
     var coronaResistance: Float = 0.0f
     open var terrainMovementDivisor: Float = 40f
     private val affecting: MutableSet<FleetMemberAPI> = HashSet()
@@ -38,7 +33,6 @@ open class MPC_coronaResistScript(val entity: SectorEntityToken,): niko_MPC_base
     }
 
     private fun iterateThroughAffected(){
-        //if(logger==null){logger=Logger.getLogger("MPC_coronaResistScript")}
         val iter = affecting.iterator()
         val fleetBin: MutableSet<CampaignFleetAPI> = HashSet()
 
@@ -55,7 +49,6 @@ open class MPC_coronaResistScript(val entity: SectorEntityToken,): niko_MPC_base
                 shouldRemove=true
             }
             if(shouldRemove){
-                //logger.info("MPC_coronaResistScript:shouldRemove:"+it.id)
                 unAffectFleetMember(it)
                 iter.remove()
             }

--- a/src/data/scripts/campaign/MPC_coronaResistScript.kt
+++ b/src/data/scripts/campaign/MPC_coronaResistScript.kt
@@ -44,7 +44,7 @@ open class MPC_coronaResistScript(val entity: SectorEntityToken,): niko_MPC_base
             }
             else if (!shouldAffectFleet((it.fleetData.fleet))){
                 if (!fleetBin.contains(it.fleetData.fleet)){
-                    fleetBin.add(it.fleetData.fleet)
+                    fleetBin += it.fleetData.fleet
                 }
                 shouldRemove=true
             }

--- a/src/data/scripts/campaign/MPC_coronaResistScript.kt
+++ b/src/data/scripts/campaign/MPC_coronaResistScript.kt
@@ -1,6 +1,7 @@
 package data.scripts.campaign
 
 import com.fs.starfarer.api.campaign.*
+import com.fs.starfarer.api.fleet.FleetAPI
 import com.fs.starfarer.api.fleet.FleetMemberAPI
 import com.fs.starfarer.api.impl.campaign.ids.Stats
 import com.fs.starfarer.api.util.Misc
@@ -11,13 +12,17 @@ import data.utilities.niko_MPC_fleetUtils.counterTerrainMovement
 import data.utilities.niko_MPC_ids
 import data.utilities.niko_MPC_ids.CORONA_RESIST_MEMORY_FLAG
 import data.utilities.niko_MPC_industryIds
+import com.fs.starfarer.api.util.IntervalUtil
+//import org.apache.log4j.Logger;
 
-open class MPC_coronaResistScript(
-    val entity: SectorEntityToken,
-): niko_MPC_baseNikoScript() {
+
+
+open class MPC_coronaResistScript(val entity: SectorEntityToken,): niko_MPC_baseNikoScript() {
+    //var logger: Logger = Logger.getLogger("MPC_coronaResistScript")
     var coronaResistance: Float = 0.0f
     open var terrainMovementDivisor: Float = 40f
-    val affecting: MutableSet<FleetMemberAPI> = HashSet()
+    private val affecting: MutableSet<FleetMemberAPI> = HashSet()
+    var interval = IntervalUtil(1f, 1f);
 
     override fun startImpl() {
         entity.addScript(this)
@@ -32,20 +37,66 @@ open class MPC_coronaResistScript(
         return false
     }
 
+    private fun iterateThroughAffected(){
+        //if(logger==null){logger=Logger.getLogger("MPC_coronaResistScript")}
+        val iter = affecting.iterator()
+        val fleetBin: MutableSet<CampaignFleetAPI> = HashSet()
+
+        while (iter.hasNext()){
+            val it = iter.next()
+            var shouldRemove=false
+            if((it.fleetData==null)||(it.fleetData.fleet==null)){
+                shouldRemove=true
+            }
+            else if (!shouldAffectFleet((it.fleetData.fleet))){
+                if (!fleetBin.contains(it.fleetData.fleet)){
+                    fleetBin.add(it.fleetData.fleet)
+                }
+                shouldRemove=true
+            }
+            if(shouldRemove){
+                //logger.info("MPC_coronaResistScript:shouldRemove:"+it.id)
+                unAffectFleetMember(it)
+                iter.remove()
+            }
+        }
+
+        val iter2=fleetBin.iterator()
+        while (iter2.hasNext()) {
+            val it = iter2.next()
+            it.memoryWithoutUpdate?.unset(CORONA_RESIST_MEMORY_FLAG)
+            iter2.remove()
+        }
+    }
+
     override fun advance(amount: Float) {
         val days = Misc.getDays(amount)
+        if (interval==null){interval = IntervalUtil(1f, 1f);}
 
-        unapplyToFleets()
-
+        interval.advance(days)
+        if(interval.intervalElapsed()) {
+            iterateThroughAffected()
+        }
         interateThroughFleets(days)
     }
 
     open fun unapplyToFleets() {
-        for (member in affecting) {
-            member.fleetData?.fleet?.memoryWithoutUpdate?.unset(CORONA_RESIST_MEMORY_FLAG)
-            member.stats.dynamic.getStat(Stats.CORONA_EFFECT_MULT).unmodify("${entity.id}_coronaEffect")
+        val iter = affecting.iterator()
+        val fleetBin: MutableSet<CampaignFleetAPI> = HashSet()
+        while (iter.hasNext()){
+            val it = iter.next()
+            if (((it.fleetData!=null)&&(it.fleetData.fleet != null))&&(!fleetBin.contains(it.fleetData.fleet))) {
+                fleetBin.add(it.fleetData.fleet)
+            }
+            unAffectFleetMember(it)
+            iter.remove()
         }
         affecting.clear()
+        val iter2=fleetBin.iterator()
+        while (iter2.hasNext()) {
+            val it = iter2.next()
+            it.memoryWithoutUpdate?.unset(CORONA_RESIST_MEMORY_FLAG)
+        }
     }
 
     private fun interateThroughFleets(days: Float) {
@@ -55,24 +106,32 @@ open class MPC_coronaResistScript(
         }
     }
 
+    private fun affectFleetMember(member: FleetMemberAPI){
+        member.stats.dynamic.getStat(Stats.CORONA_EFFECT_MULT).modifyMult(
+            "${entity.id}_MPCspecialCoronaResistance",
+            coronaResistance,
+            "Unknown corona resistance"
+        )
+    }
+
+    private fun unAffectFleetMember(member: FleetMemberAPI){
+        member.stats.dynamic.getStat(Stats.CORONA_EFFECT_MULT).unmodify("${entity.id}_MPCspecialCoronaResistance")
+    }
+
     private fun affectFleet(fleet: CampaignFleetAPI, days: Float) {
         fleet.counterTerrainMovement(days, terrainMovementDivisor) // this doesnt seem to work very well either, its inconsistant between fleets
-
         fleet.memoryWithoutUpdate.set(CORONA_RESIST_MEMORY_FLAG, coronaResistance, 1f)
+
         for (fleetMember in fleet.fleetData.membersListCopy) {
-            fleetMember.stats.dynamic.getStat(Stats.CORONA_EFFECT_MULT).modifyMult(
-                "${entity.id}_MPCspecialCoronaResistance",
-                coronaResistance,
-                "Unknown corona resistance"
-            )
-            affecting += fleetMember
+            if (!affecting.contains(fleetMember)){
+                affectFleetMember(fleetMember)
+                affecting.add(fleetMember)
+            }
         }
     }
 
     open fun shouldAffectFleet(fleet: CampaignFleetAPI): Boolean {
-        if (fleet.isInHyperspaceTransition) return false
-
-        return true
+        return !fleet.isInHyperspaceTransition
     }
 
     open fun getTargetFleets(): MutableSet<CampaignFleetAPI> {

--- a/src/data/scripts/campaign/econ/industries/MPC_coronaResistStructure.kt
+++ b/src/data/scripts/campaign/econ/industries/MPC_coronaResistStructure.kt
@@ -21,9 +21,9 @@ class MPC_coronaResistStructure: baseNikoIndustry() {
 
     override fun apply() {
         super.apply(true)
-
+        if (reapplying) return
         script = MPC_coronaResistStructureScript(market.primaryEntity, this)
-        script!!.start()
+        if (!script!!.started){script!!.start()}
     }
 
     override fun unapply() {


### PR DESCRIPTION
Short summary:
industry no longer spam starts corona resist script.
corona resist script refactored, effect fades in one-day intervals, performance somewhat improved.


Long summary:
The first problem, the bigger one overall which caused the majority of the lag, was that the structure script was running apply more than it should have, which was causing the script to be started repeatedly. Added code checks to prevent reapply from starting a new script instance repeatedly (maybe the return if reapplying is redundant, but it should be fine)

The second 'problem' was that the code was getting bogged down by excessive operations, though admittedly it may have been primarily a problem due to problem 1.  Still, I kinda recommend keeping this set of changes: instead of operating on all the ships every frame, the refactor modifies each ship once and adds it to the affecting hasmap as usual. However, unapplytofleets is only called when  the script is meant to terminate. Instead, every 1 ingame day the affecting map is iterated through, ships that are no longer to be modified are selected and their fleet, if applicable, is added to a list which is later iterated through to remove modifications, then the ships have the modification removed. 
The hope for this latter set of edits is that it will substantially reduce per-frame overhead, which was notably problematic with substantial ships.

The result of the refactoring overall is that my home system, which was chugging badly even w/o the first problem's influence, now only has its usual performance hitches.

